### PR TITLE
feat: sign base64 data, add mutex to lock

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,8 @@
 package kalkan
 
 import (
+	"sync"
+
 	"github.com/Zulbukharov/GoKalkan/pkg/dlopen"
 )
 
@@ -10,6 +12,7 @@ var dynamicLibs = []string{"libkalkancryptwr-64.so"}
 // Client структура для взаимодействия с библиотекой Kalkan
 type Client struct {
 	handler *dlopen.LibHandle
+	mu      sync.Mutex
 }
 
 // NewClient возвращает клиента для работы с Kalkan

--- a/examples/sign_and_verify/main.go
+++ b/examples/sign_and_verify/main.go
@@ -32,4 +32,5 @@ func main() {
 	serial, err := cli.VerifyXML(xml)
 	fmt.Println("serial", serial)
 	fmt.Println("err", err)
+
 }

--- a/method_load_keystore.go
+++ b/method_load_keystore.go
@@ -23,6 +23,9 @@ func (cli *Client) LoadKeyStore(password, containerPath string) error {
 	alias := C.CString("")
 	defer C.free(unsafe.Pointer(alias))
 
+	cli.mu.Lock()
+	defer cli.mu.Unlock()
+
 	rc := (int)(C.loadKeyStore(
 		(C.int)(storage),
 		Cpassword,

--- a/method_sign_data.go
+++ b/method_sign_data.go
@@ -1,0 +1,53 @@
+package kalkan
+
+// #cgo LDFLAGS: -ldl
+// #include <dlfcn.h>
+// #include <strings.h>
+// #include "cpp/KalkanCrypt.h"
+//
+// unsigned long signData(char *alias, int flag, char *inData, int inDataLength, unsigned char *inSign, int inSignLen, unsigned char *outSign, int *outSignLength) {
+//     bzero(outSign, *outSignLength);
+//     return kc_funcs->SignData(alias, flag, inData, inDataLength, inSign, inSignLen, outSign, outSignLength);
+// }
+import "C"
+import (
+	"unsafe"
+)
+
+const (
+	// KC_SIGN_CMS | KC_IN_BASE64 | KC_OUT_BASE6
+	SignBase64 = 2066
+)
+
+// SignData используется для подписи текста в формате base64
+func (cli *Client) SignData(data string) (string, error) {
+	alias := C.CString("")
+	defer C.free(unsafe.Pointer(alias))
+
+	inData := C.CString(data)
+	defer C.free(unsafe.Pointer(inData))
+	inDataLength := len(data)
+
+	outSignLength := 50000 + 2*inDataLength
+	outSign := C.malloc((C.ulong)(C.sizeof_uchar * outSignLength))
+	defer C.free(outSign)
+
+	inSignLength := 50000 + 2*inDataLength
+	inSign := C.malloc((C.ulong)(C.sizeof_uchar * inSignLength))
+	defer C.free(inSign)
+
+	cli.mu.Lock()
+	defer cli.mu.Unlock()
+
+	rc := (int)(C.signData(
+		alias,
+		(C.int)(SignBase64),
+		inData,
+		(C.int)(inDataLength),
+		(*C.uchar)(inSign),
+		(C.int)(inSignLength),
+		(*C.uchar)(outSign),
+		(*C.int)(unsafe.Pointer(&outSignLength)),
+	))
+	return C.GoString((*C.char)(outSign)), cli.returnErr(rc)
+}

--- a/method_sign_xml.go
+++ b/method_sign_xml.go
@@ -8,13 +8,14 @@ package kalkan
 //     return kc_funcs->SignXML(alias, flags, inData, inDataLength, outSign, outSignLength, signNodeId, parentSignNode, parentNameSpace);
 // }
 import "C"
-import "unsafe"
+import (
+	"unsafe"
+)
 
 // SignXML подписывает данные в формате XML
 func (cli *Client) SignXML(data string) (string, error) {
 	alias := C.CString("")
 	defer C.free(unsafe.Pointer(alias))
-
 	flag := 0
 
 	inData := C.CString(data)
@@ -34,6 +35,9 @@ func (cli *Client) SignXML(data string) (string, error) {
 	parentNameSpace := C.CString("")
 	defer C.free(unsafe.Pointer(parentNameSpace))
 
+	cli.mu.Lock()
+	defer cli.mu.Unlock()
+
 	rc := (int)(C.signXML(
 		alias,
 		(C.int)(flag),
@@ -45,6 +49,7 @@ func (cli *Client) SignXML(data string) (string, error) {
 		parentSignNode,
 		parentNameSpace,
 	))
+
 	signedXML := C.GoString((*C.char)(outSign))
 
 	return signedXML, cli.returnErr(rc)

--- a/method_verify_data.go
+++ b/method_verify_data.go
@@ -54,6 +54,9 @@ func (cli *Client) VerifyData(data string) (*VerifiedData, error) {
 	var outCert [OutCertLength]byte
 	outCertLen := OutCertLength
 
+	cli.mu.Lock()
+	defer cli.mu.Unlock()
+
 	rc := (int)(C.verifyData(
 		alias,
 		(C.int)(flag),

--- a/method_verify_xml.go
+++ b/method_verify_xml.go
@@ -29,6 +29,9 @@ func (cli *Client) VerifyXML(xml string) (string, error) {
 	outVerifyInfo := C.malloc((C.ulong)(C.sizeof_char * outVerifyInfoLen))
 	defer C.free(outVerifyInfo)
 
+	cli.mu.Lock()
+	defer cli.mu.Unlock()
+
 	rc := (int)(C.verifyXML(
 		alias,
 		(C.int)(flags),

--- a/method_x509_export_from_store.go
+++ b/method_x509_export_from_store.go
@@ -20,6 +20,9 @@ func (cli *Client) X509ExportCertificateFromStore() (string, error) {
 	alias := C.CString("")
 	defer C.free(unsafe.Pointer(alias))
 
+	cli.mu.Lock()
+	defer cli.mu.Unlock()
+
 	rc := (int)(C.x509ExportCertificateFromStore(
 		alias,
 		(C.int)(flag),


### PR DESCRIPTION
- Добавлена реализация метода SignData, которая позволяет подписать строку в формате base64.
- Добавлена очистка буфера при вызове метода SignData.
- Добавлены локи для работы с большим количеством горутин.

